### PR TITLE
Fix insertion of entries when IDs are not increasing.

### DIFF
--- a/interval/int_interval.go
+++ b/interval/int_interval.go
@@ -236,14 +236,14 @@ func (n *IntNode) insert(e IntInterface, r IntRange, id uintptr, fast bool) (roo
 
 	switch c := r.Start - n.Interval.Start; {
 	case c == 0:
-		switch cid := id - n.Elem.ID(); {
-		case cid == 0:
+		switch {
+		case id == n.Elem.ID():
 			n.Elem = e
 			n.Interval = r
 			if !fast {
 				n.Range.End = r.End
 			}
-		case cid < 0:
+		case id < n.Elem.ID():
 			n.Left, d = n.Left.insert(e, r, id, fast)
 		default:
 			n.Right, d = n.Right.insert(e, r, id, fast)
@@ -446,10 +446,10 @@ func (n *IntNode) floor(m int, id uintptr) *IntNode {
 	}
 	switch c := m - n.Interval.Start; {
 	case c == 0:
-		switch cid := id - n.Elem.ID(); {
-		case cid == 0:
+		switch {
+		case id == n.Elem.ID():
 			return n
-		case cid < 0:
+		case id < n.Elem.ID():
 			return n.Left.floor(m, id)
 		default:
 			if r := n.Right.floor(m, id); r != nil {
@@ -485,10 +485,10 @@ func (n *IntNode) ceil(m int, id uintptr) *IntNode {
 	}
 	switch c := m - n.Interval.Start; {
 	case c == 0:
-		switch cid := id - n.Elem.ID(); {
-		case cid == 0:
+		switch {
+		case id == n.Elem.ID():
 			return n
-		case cid > 0:
+		case id > n.Elem.ID():
 			return n.Right.ceil(m, id)
 		default:
 			if l := n.Left.ceil(m, id); l != nil {

--- a/interval/int_interval_test.go
+++ b/interval/int_interval_test.go
@@ -655,6 +655,18 @@ func (s *S) TestIssue15Int(c *check.C) {
 	c.Check(len(got), check.Equals, 1, check.Commentf("Expected one overlap, got %d", len(got)))
 }
 
+func (s *S) TestIntInsertBug(c *check.C) {
+	var t IntTree
+	for i := 10; i > 0; i-- {
+		t.Insert(&intOverlap{start: 0, end: 1, id: uintptr(i)}, false)
+	}
+	c.Check(t.Len(), check.Equals, 10, check.Commentf("Expected 10 entries, got %d", t.Len()))
+	for i := 1; i <= 10; i++ {
+		t.Delete(&intOverlap{start: 0, end: 1, id: uintptr(i)}, false)
+	}
+	c.Check(t.Len(), check.Equals, 0, check.Commentf("Expected 0 entries, got %d", t.Len()))
+}
+
 func (t *IntTree) dot(label string) string {
 	if t == nil {
 		return ""

--- a/interval/interval.go
+++ b/interval/interval.go
@@ -276,13 +276,13 @@ func (n *Node) insert(e Interface, min Comparable, id uintptr, fast bool) (root 
 
 	switch c := min.Compare(n.Elem.Start()); {
 	case c == 0:
-		switch cid := id - n.Elem.ID(); {
-		case cid == 0:
+		switch {
+		case id == n.Elem.ID():
 			n.Elem = e
 			if !fast {
 				n.Range.SetEnd(e.End())
 			}
-		case cid < 0:
+		case id < n.Elem.ID():
 			n.Left, d = n.Left.insert(e, min, id, fast)
 		default:
 			n.Right, d = n.Right.insert(e, min, id, fast)
@@ -483,10 +483,10 @@ func (n *Node) floor(m Comparable, id uintptr) *Node {
 	}
 	switch c := m.Compare(n.Elem.Start()); {
 	case c == 0:
-		switch cid := id - n.Elem.ID(); {
-		case cid == 0:
+		switch {
+		case id == n.Elem.ID():
 			return n
-		case cid < 0:
+		case id < n.Elem.ID():
 			return n.Left.floor(m, id)
 		default:
 			if r := n.Right.floor(m, id); r != nil {
@@ -522,10 +522,10 @@ func (n *Node) ceil(m Comparable, id uintptr) *Node {
 	}
 	switch c := m.Compare(n.Elem.Start()); {
 	case c == 0:
-		switch cid := id - n.Elem.ID(); {
-		case cid == 0:
+		switch {
+		case id == n.Elem.ID():
 			return n
-		case cid > 0:
+		case id > n.Elem.ID():
 			return n.Right.ceil(m, id)
 		default:
 			if l := n.Left.ceil(m, id); l != nil {

--- a/interval/interval_test.go
+++ b/interval/interval_test.go
@@ -789,6 +789,18 @@ func (s *S) TestIssue15(c *check.C) {
 	c.Check(len(got), check.Equals, 1, check.Commentf("Expected one overlap, got %d", len(got)))
 }
 
+func (s *S) TestInsertBug(c *check.C) {
+	var t Tree
+	for i := 10; i > 0; i-- {
+		t.Insert(&overlap{start: 0, end: 1, id: uintptr(i)}, false)
+	}
+	c.Check(t.Len(), check.Equals, 10, check.Commentf("Expected 10 entries, got %d", t.Len()))
+	for i := 1; i <= 10; i++ {
+		t.Delete(&overlap{start: 0, end: 1, id: uintptr(i)}, false)
+	}
+	c.Check(t.Len(), check.Equals, 0, check.Commentf("Expected 0 entries, got %d", t.Len()))
+}
+
 func (t *Tree) dot(label string) string {
 	if t == nil {
 		return ""


### PR DESCRIPTION
Tree.Insert was not properly inserting entries when the ID() was smaller
than an existing entry due to an invalid comparison of an unsigned
integer less than 0.
